### PR TITLE
Add explicit option parsing

### DIFF
--- a/bin/rspectre
+++ b/bin/rspectre
@@ -3,8 +3,19 @@
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
-require 'bundler/setup'
+require 'shellwords'
+require 'optparse'
 
 require 'rspectre'
 
-RSpectre::Runner.new(*ARGV).lint
+options = { rspec: [] }
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: rspectre [options]"
+
+  opts.on('--rspec RSPEC_ARGS', 'Arguments to feed to RSpec.') do |value|
+    options[:rspec] = value.shellsplit
+  end
+end.parse(ARGV)
+
+RSpectre::Runner.new(options.fetch(:rspec)).lint

--- a/lib/rspectre/runner.rb
+++ b/lib/rspectre/runner.rb
@@ -6,9 +6,7 @@ module RSpectre
 
     EXIT_SUCCESS = 0
 
-    def initialize(*rspec_arguments)
-      rspec_arguments << 'spec' if rspec_arguments.empty?
-
+    def initialize(rspec_arguments)
       super(
         RSpec::Core::Runner.new(RSpec::Core::ConfigurationOptions.new(rspec_arguments)),
         RSpec.world

--- a/spec/shared/highlighted_offenses.rb
+++ b/spec/shared/highlighted_offenses.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'highlighted offenses' do |src|
     rspectre_path = File.expand_path('bin/rspectre')
 
     Dir.chdir(File.dirname(spec_file.path)) do
-      Open3.capture3("#{rspectre_path} #{spec_file.path}")
+      Open3.capture3("#{rspectre_path} --rspec #{spec_file.path}")
     end
   end
 


### PR DESCRIPTION
- Changes the public interface to require the `--rspec` flag for
  optional rspec arguments instead of directly passing ARGV to rspec.
  This allows adding future flags to `rspectre` without conflict.