### PR TITLE
Fix default rspec argument

### DIFF
--- a/bin/rspectre
+++ b/bin/rspectre
@@ -8,7 +8,7 @@ require 'optparse'
 
 require 'rspectre'
 
-options = { rspec: [] }
+options = { rspec: %w[spec] }
 
 OptionParser.new do |opts|
   opts.banner = "Usage: rspectre [options]"


### PR DESCRIPTION
- It appears that passing an empty array for configuration does not run
  any specs--unlike the `rspec` binary which runs the specs in `spec/`
  by default.