### PR TITLE
Fix ruby shebang

### DIFF
--- a/bin/rspectre
+++ b/bin/rspectre
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))


### PR DESCRIPTION
- Use env so that the user's default `ruby` is selected by default.