### PR TITLE
Fail fast by default

### DIFF
--- a/bin/rspectre
+++ b/bin/rspectre
@@ -8,7 +8,7 @@ require 'optparse'
 
 require 'rspectre'
 
-options = { rspec: %w[spec], autocorrect: false }
+options = { rspec: %w[--fail-fast spec], autocorrect: false }
 
 OptionParser.new do |opts|
   opts.banner = 'Usage: rspectre [options]'


### PR DESCRIPTION
- Since `rspectre` just aborts and outputs nothing if the original test
  suite fails, it definitely makes sense to bail early if we can.