### PR TITLE
Remove heredocs properly when auto correcting

### DIFF
--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -2,23 +2,71 @@
 
 module RSpectre
   class AutoCorrector < Parser::Rewriter
-    include Concord.new(:filename, :nodes)
+    include Concord.new(:filename, :nodes, :buffer)
 
-    def correct
+    def initialize(filename, nodes)
       buffer = Parser::Source::Buffer.new("(#{filename})")
       buffer.source = File.read(filename)
 
+      super(filename, nodes, buffer)
+    end
+
+    def correct
       File.open(filename, 'w') do |file|
         file.write(rewrite(buffer, Parser::CurrentRuby.new.parse(buffer)))
       end
     end
 
     def on_block(node)
-      remove(node.location.expression) if nodes.any? do |offense_node|
+      remove(removal_range(node)) if nodes.any? do |offense_node|
         node == offense_node && node.location.line == offense_node.location.line
       end
 
       super
+    end
+
+    private
+
+    # This corrects for cases which contains heredocs which do not get removed in all cases if we
+    # just use the `expression` range.
+    def removal_range(node)
+      Parser::Source::Range.new(
+        buffer,
+        node.location.expression.begin_pos,
+        range_end(node)
+      )
+    end
+
+    def range_end(node) # rubocop:disable Metrics/MethodLength
+      location = node.location.expression
+
+      last_line    = location.last_line
+      end_location = location.end
+
+      walk(node) do |child|
+        child_location = child.location
+
+        next unless child_location.respond_to?(:heredoc_end)
+
+        heredoc_end = child_location.heredoc_end
+
+        if heredoc_end.last_line > last_line
+          last_line    = heredoc_end.last_line
+          end_location = heredoc_end
+        end
+      end
+
+      end_location.end_pos
+    end
+
+    def walk(node, &block)
+      yield node
+
+      node.children.each do |child|
+        next unless child.is_a?(::Parser::AST::Node)
+
+        walk(child, &block)
+      end
     end
   end
 end

--- a/spec/auto_corrector_spec.rb
+++ b/spec/auto_corrector_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe RSpectre::AutoCorrector do
     end
   end
 
+  context 'when there is a multi-line herdoc on a single line let' do
+    let(:src) do
+      <<~RUBY
+        RSpec.describe Foo do
+          let(:unused_heredoc) { foo(<<-HERE).strip }
+            THERE
+          HERE
+        end
+      RUBY
+    end
+
+    it 'corrects multi-line heredocs in single-line lets' do
+      aggregate_failures do
+        expect do
+          described_class.new(
+            spec_file.path,
+            [RSpectre::SourceMap.parse(spec_file).find_method(:let, 2)]
+          ).correct
+        end.not_to raise_error
+
+        expect(File.read(spec_file.path)).to eql(<<~RUBY)
+          RSpec.describe Foo do\n  \nend
+        RUBY
+      end
+    end
+  end
+
   after do
     spec_file.close
     spec_file.unlink


### PR DESCRIPTION
- This solves a problem where the final line of a heredoc extends beyond
  the final line of the expression being removed. Now the entire
  expression including the herdoc should be removed.
- Fixes #15