### PR TITLE
Reduce warning noise

### DIFF
--- a/lib/rspectre/source_map.rb
+++ b/lib/rspectre/source_map.rb
@@ -20,25 +20,15 @@ module RSpectre
     end
 
     def find_method(target_selector, line)
-      candidates = find_methods(target_selector, line)
-
-      if candidates.one?
-        candidates.first
-      else
-        warn Color.yellow("Unable to resolve `#{target_selector}` on line #{line}.")
-      end
-    end
-
-    private
-
-    def find_methods(target_selector, line)
       block_nodes(line).select do |node|
         send, = *node
         _receiver, selector = *send
 
         selector.equal?(target_selector)
-      end
+      end.first
     end
+
+    private
 
     def block_nodes(line)
       map.fetch(line, []).select { |node| node.type.equal?(:block) }


### PR DESCRIPTION
- This stops emitting "Unable to resolve ..." messages since they are
  almost all the product of not being able to parse an entire file.
  Ideally this would be scoped so that it still emits a warning when
  something can't be resolved due to a logic error, but for now this is
  an improved user experience.