### PR TITLE
Remove deprecation warning

### DIFF
--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RSpectre
-  class AutoCorrector < Parser::Rewriter
+  class AutoCorrector < Parser::TreeRewriter
     include Concord.new(:filename, :nodes, :buffer)
 
     def initialize(filename, nodes)


### PR DESCRIPTION
`Parser::Rewriter` is [deprecated](https://github.com/whitequark/parser/blob/fbe0e8cbec557c96b0e0f4a8c5201155ee478284/lib/parser/rewriter.rb#L6), so we should update to `Parser::TreeRewriter`.