### PR TITLE
Pin rubocop-* to patch version

### DIFF
--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('unparser', '~> 0.2')
 
   gem.add_development_dependency('pry',           '~> 0.10')
-  gem.add_development_dependency('rubocop',       '~> 0.60')
-  gem.add_development_dependency('rubocop-rspec', '~> 1.30')
+  gem.add_development_dependency('rubocop',       '~> 0.60.0')
+  gem.add_development_dependency('rubocop-rspec', '~> 1.30.1')
 end


### PR DESCRIPTION
- I have not updated the configuration on this repo in quite some time and the floating constraint has allowed various cop changes that are not compatible with my existing config to occur. This should keep things stable until I change further config.