### PR TITLE
Remove `unparser` dependency

### DIFF
--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -9,7 +9,6 @@ require 'anima'
 require 'concord'
 require 'parser/current'
 require 'rspec'
-require 'unparser'
 
 require 'rspectre/auto_corrector'
 require 'rspectre/color'

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('concord',  '~> 0.1')
   gem.add_runtime_dependency('parser',   '~> 2.3')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
-  gem.add_runtime_dependency('unparser', '~> 0.2')
 
   gem.add_development_dependency('pry',           '~> 0.10')
   gem.add_development_dependency('rubocop',       '~> 0.60.0')


### PR DESCRIPTION
- I do not currently rely on `unparser` in any capacity. I believe this is a leftover from an early AST-rewriting-based prototype.