### PR TITLE
Explicitly require `stringio`

### DIFF
--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'pathname'
 require 'set'
+require 'stringio'
 
 require 'anima'
 require 'concord'


### PR DESCRIPTION
- Apparently I neglected to ensure that StringIO actually exists. The various codebases I have tested `rspectre` on have it directly or indirectly required already so i did not see the failure until recently testing on a new repository.