### PR TITLE
Drop ruby 2.3 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
 require:
   - rubocop-rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Master (Unreleased)]
 
+- Drop support for ruby 2.3 and 2.4 - [#34](https://github.com/dgollahon/rspectre/pull/34) ([@dgollahon])
 - Fixed a bug where `stringio` was not being required - [#32](https://github.com/dgollahon/rspectre/pull/32) ([@dgollahon])
 - Removed `unparser` dependency - [#31](https://github.com/dgollahon/rspectre/pull/31) ([@dgollahon])
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ to your Gemfile.
 
 ##### Supported Ruby Versions
 
-`rspectre` currently supports Ruby 2.3 and 2.4. I may add 2.2 support in the future.
+`rspectre` currently supports Ruby 2.5+
 
 ### Usage
 

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'http://github.com/dgollahon/rspectre'
   gem.license     = 'MIT'
 
-  gem.required_ruby_version = '>= 2.3'
+  gem.required_ruby_version = '>= 2.5'
 
   gem.add_runtime_dependency('anima',    '~> 0.3')
   gem.add_runtime_dependency('concord',  '~> 0.1')


### PR DESCRIPTION
- `rspectre` now officially only supports non-EOL rubies, 2.5+