### PR TITLE
Add success message when `rspectre` succeeds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.5.8
     environment:
       CODECLIMATE_REPO_TOKEN: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,27 +34,31 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: true
+Metrics/AbcSize:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
 Metrics/LineLength:
   Max: 100
 Metrics/BlockLength:
   Exclude:
-  # Ignore RSpec DSL
-  - spec/**/*
+    # Ignore RSpec DSL
+    - spec/**/*
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 Style/Next:
   EnforcedStyle: always
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%i': '[]'
-    '%I': '[]'
-    '%q': '{}'
-    '%Q': '{}'
-    '%r': '{}'
-    '%s': ()
-    '%w': '[]'
-    '%W': '[]'
-    '%x': ()
+    "%i": "[]"
+    "%I": "[]"
+    "%q": "{}"
+    "%Q": "{}"
+    "%r": "{}"
+    "%s": ()
+    "%w": "[]"
+    "%W": "[]"
+    "%x": ()
 Style/TrivialAccessors:
   ExactNameMatch: false
 Style/SymbolArray:
@@ -88,6 +92,8 @@ Style/LambdaCall:
 RSpec/MessageExpectation:
   Enabled: true
 RSpec/ExampleLength:
+  Enabled: false
+RSpec/MultipleExpectations:
   Enabled: false
 RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Master (Unreleased)]
 
-- Drop support for ruby 2.3 and 2.4 - [#34](https://github.com/dgollahon/rspectre/pull/34) ([@dgollahon])
+- Added success message if no unused setup is found - [#35](https://github.com/dgollahon/rspectre/pull/35) ([@dgollahon])
+- Dropped support for ruby 2.3 and 2.4 - [#34](https://github.com/dgollahon/rspectre/pull/34) ([@dgollahon])
 - Fixed a bug where `stringio` was not being required - [#32](https://github.com/dgollahon/rspectre/pull/32) ([@dgollahon])
 - Removed `unparser` dependency - [#31](https://github.com/dgollahon/rspectre/pull/31) ([@dgollahon])
 

--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -37,7 +37,7 @@ module RSpectre
       )
     end
 
-    def range_end(node) # rubocop:disable Metrics/MethodLength
+    def range_end(node)
       location = node.location.expression
 
       last_line    = location.last_line

--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -8,7 +8,7 @@ module RSpectre
       RSpec::Core::ExampleGroup
     end
 
-    def self.register(selector, locations) # rubocop:disable Metrics/MethodLength
+    def self.register(selector, locations)
       location = locations.first
 
       file = File.realpath(location.path)

--- a/lib/rspectre/linter/unused_shared_setup.rb
+++ b/lib/rspectre/linter/unused_shared_setup.rb
@@ -5,7 +5,7 @@ module RSpectre
     class UnusedSharedSetup < self
       TAG = 'UnusedSharedSetup'
 
-      def self.redefine_shared(receiver, method) # rubocop:disable Metrics/MethodLength
+      def self.redefine_shared(receiver, method)
         # Capture the original class method
         original_method = receiver.method(method)
 

--- a/lib/rspectre/runner.rb
+++ b/lib/rspectre/runner.rb
@@ -19,6 +19,8 @@ module RSpectre
     def handle_offenses
       if TRACKER.offenses?
         auto_correct ? TRACKER.correct_offenses : TRACKER.report_offenses
+      else
+        puts 'No unused test setup detected.'
       end
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe RSpectre::Runner do
+  include_context 'rspectre runner'
+
+  it 'outputs a success message' do
+    source = <<~RUBY
+      RSpec.describe 'nothing of interest here' do
+        let(:a) { 1 }
+
+        it 'is 1' do
+          expect(a).to be(1)
+        end
+      end
+    RUBY
+
+    run_rspectre(source) do |(stdout, _stderr, status), _spec_file|
+      expect(status.to_i).to be(0)
+      expect(stdout).to eql("No unused test setup detected.\n")
+    end
+  end
+end

--- a/spec/shared/rspectre_runner.rb
+++ b/spec/shared/rspectre_runner.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'rspectre runner' do # rubocop:disable RSpec/ContextWording
+  def run_rspectre(source)
+    spec_file =
+      Tempfile.new.tap do |file|
+        file.write(source.gsub(/^\s*\^+.+\n/, ''))
+        file.flush
+      end
+
+    rspectre_path = File.expand_path('bin/rspectre')
+
+    output =
+      Dir.chdir(File.dirname(spec_file.path)) do
+        Open3.capture3("#{rspectre_path} --rspec #{spec_file.path}")
+      end
+
+    yield([output, spec_file])
+  ensure
+    spec_file.close
+    spec_file.unlink
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'tempfile'
 require 'rspectre'
 
 require 'shared/highlighted_offenses'
+require 'shared/rspectre_runner'
 
 RSpec.configure do |config|
   # Forbid RSpec from monkey patching any of our objects


### PR DESCRIPTION
- Closes #30
- Tweaks a few overly aggressive rubocop settings as well.