### PR TITLE
Output rspec output on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Master (Unreleased)]
 
+- Added rspec output if the specs fail during an `rspectre` run - [#36](https://github.com/dgollahon/rspectre/pull/36) ([@dgollahon])
 - Added success message if no unused setup is found - [#35](https://github.com/dgollahon/rspectre/pull/35) ([@dgollahon])
 - Dropped support for ruby 2.3 and 2.4 - [#34](https://github.com/dgollahon/rspectre/pull/34) ([@dgollahon])
 - Fixed a bug where `stringio` was not being required - [#32](https://github.com/dgollahon/rspectre/pull/32) ([@dgollahon])

--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -28,4 +28,5 @@ require 'rspectre/linter/unused_shared_setup'
 
 module RSpectre
   TRACKER = Tracker.new
+  LIB_PATH = Pathname.new(File.expand_path('../lib', __dir__))
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -19,4 +19,44 @@ RSpec.describe RSpectre::Runner do
       expect(stdout).to eql("No unused test setup detected.\n")
     end
   end
+
+  it 'outputs rspec messages when the tests fail' do
+    source = <<~RUBY
+      RSpec.describe 'failures' do
+        it { raise 'uh oh' }
+      end
+    RUBY
+
+    run_rspectre(source) do |(stdout, stderr, status), _spec_file|
+      expect(status.to_i).to be > 0
+      expect(stdout).to eql('')
+      expect(
+        stderr.gsub(/\d\.\d+/, '<time>').gsub(/\S+\.rb/, '<file>').strip
+      ).to eql(<<~ERROR.strip)
+        \e[31mRunning the specs failed. Either your tests do not pass normally or this is a bug in RSpectre.\e[0m
+
+        RSpec Output:
+        ---
+        F
+
+        Failures:
+
+          1) failures \n\
+             Failure/Error: it { raise 'uh oh' }
+
+             RuntimeError:
+               uh oh
+             # <file>:2:in `block (2 levels) in <top (required)>'
+             # <file>:56:in `run_specs'
+             # <file>:15:in `lint'
+
+        Finished in <time> seconds (files took <time> seconds to load)
+        1 example, 1 failure
+
+        Failed examples:
+
+        rspec <file>:2 # failures
+      ERROR
+    end
+  end
 end

--- a/spec/shared/rspectre_runner.rb
+++ b/spec/shared/rspectre_runner.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context 'rspectre runner' do # rubocop:disable RSpec/ContextWording
   def run_rspectre(source)
     spec_file =
-      Tempfile.new.tap do |file|
+      Tempfile.new(%w[spec_file .rb]).tap do |file|
         file.write(source.gsub(/^\s*\^+.+\n/, ''))
         file.flush
       end


### PR DESCRIPTION
- This will help users understand why `rspectre` was unable to complete and will assist in making clear bug reports as well.
- Also mildly simplifies our RSpec invocation code.
- Closes #29