### PR TITLE
Revert "Reduce warning noise"

### DIFF
--- a/lib/rspectre/source_map.rb
+++ b/lib/rspectre/source_map.rb
@@ -20,15 +20,25 @@ module RSpectre
     end
 
     def find_method(target_selector, line)
+      candidates = find_methods(target_selector, line)
+
+      if candidates.one?
+        candidates.first
+      else
+        warn Color.yellow("Unable to resolve `#{target_selector}` on line #{line}.")
+      end
+    end
+
+    private
+
+    def find_methods(target_selector, line)
       block_nodes(line).select do |node|
         send, = *node
         _receiver, selector = *send
 
         selector.equal?(target_selector)
-      end.first
+      end
     end
-
-    private
 
     def block_nodes(line)
       map.fetch(line, []).select { |node| node.type.equal?(:block) }


### PR DESCRIPTION
Reverts dgollahon/rspectre#19

In light of #26, this workaround should not be necessary. It would be better to be able to see when `rspectre` cannot locate a node, as long as it is not an overwhelming stream as could be the case before #26.