### PR TITLE
Fix a dependency

### DIFF
--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('anima',    '~> 0.3')
   gem.add_runtime_dependency('concord',  '~> 0.1')
-  gem.add_runtime_dependency('parser',   '~> 2.3')
+  gem.add_runtime_dependency('parser',   '~> 2.5')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 
   gem.add_development_dependency('pry',           '~> 0.10')


### PR DESCRIPTION
Reproduction script
---

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'parser', '2.4.0.2'
  gem 'rspectre'
end
```

This causes the following error.

```
/Users/chiastolite/.anyenv/envs/rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/rspectre-0.0.3/lib/rspectre/auto_corrector.rb:4:in `<module:RSpectre>': uninitialized constant Parser::TreeRewriter (NameError)
```

Because Parser::TreeRewriter is available since parser 2.5.0 or later.

This is related to #21 