### PR TITLE
Fix `parser` version constraint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.8
+      - image: circleci/ruby:2.5.9
     environment:
       CODECLIMATE_REPO_TOKEN: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
     steps:

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('anima',    '~> 0.3')
   gem.add_runtime_dependency('concord',  '~> 0.1')
-  gem.add_runtime_dependency('parser',   '~> 2.3')
+  gem.add_runtime_dependency('parser',   '>= 2.5')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 
   gem.add_development_dependency('pry',           '~> 0.10')


### PR DESCRIPTION
- As pointed out in #42 (thanks @chiastolite!), `rspectre` uses features from `parser` that are only available in 2.5 (see #21). The APIs that are in use should also be compatible with 3.x and because `parser` is intended to have a permanently stable API (or, as close to that as possible), this can just be changed to >= 2.5 for now.