### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 [![Test Coverage](https://codeclimate.com/github/dgollahon/rspectre/badges/coverage.svg)](https://codeclimate.com/github/dgollahon/rspectre/coverage)
 [![Gem Version](https://badge.fury.io/rb/rspectre.svg)](https://badge.fury.io/rb/rspectre)
 
-`rspectre` is a tool for hunting the dead and errant code haunting your test suite. It picks up where static analysis tools like [rubocop-rspec](https://github.com/backus/rubocop-rspec) leave off by analyzing your test suite as it runs.
+`rspectre` is a tool to remove the dead and errant code haunting your test suite.
 
-This project is still a bit of a work in progress. In particular, `--auto-correct` is still experimental and may leave behind awkward whitespace or otherwise misbehave. YMMV.
+Static analysis tools like [rubocop-rspec](https://github.com/backus/rubocop-rspec), while very helpful in their own right, generally cannot detect most unused or misused test setup (especially when it spans multiple files) or are forced to have high false positive rates.
 
-Happy testing!
-
-### The Tool In Action
-
-It can sometimes be difficult to determine where and if test setup is used--especially if it exists across multiple files. Since `rspectre` probes your test suite while it runs, it can reliably detect a number of common mistakes.
+`rspectre` works a bit differently. By probing your test suite as it runs, `rspectre` can reliably detect and remove a number of common mistakes with virtually no false positives, including:
+* Unused `let` statements
+* Unused `subject` statements
+* Unused `shared_context` and `shared_examples` statements
 
 ##### Example Spec
 
@@ -51,16 +50,6 @@ end
 
 ![tool output](http://i.imgur.com/lbowIrc.png)
 
-### Planned Features
-
-- [x] Detect unused `let` statements
-- [x] Detect unused `subject` statements
-- [x] Detect unused `shared_examples` and `shared_contexts`
-- [x] Automatically delete dead code
-- [ ] Detect unused double arguments
-
-I have some other ideas in mind as well, but haven't evaluated how feasible they are yet.
-
 ### Installation
 
 To install `rspectre`, run:
@@ -76,10 +65,6 @@ gem 'rspectre'
 ```
 
 to your Gemfile.
-
-##### Supported Ruby Versions
-
-`rspectre` currently supports Ruby 2.5+
 
 ### Usage
 
@@ -101,12 +86,14 @@ If you want to automatically delete dead code that `rspectre` finds, simply use 
 $ rspectre --auto-correct
 ```
 
+Note: `--auto-correct` is unpolished and may leave behind awkward whitespace or otherwise misbehave. YMMV.
+
 ##### NOTE
 
-You should generally run your _entire_ test suite with `rspectre`. `rspectre` inserts probes in all of your specs and helpers as they are `require`'d and then waits to observe them being used. If, for example, your spec helper requires all your shared examples but you only run a subset of your tests (which don't happen to use all of the aforementioned shared examples), it may appear to `rspectre` like some of those shared examples are unused when they are not. I may consider trying to handle for some of these cases in the future, but for now just run your whole test suite or else you'll have to sift through some false positives.
+You should generally run your _entire_ test suite with `rspectre`. `rspectre` inserts probes in all of your specs and helpers as they are `require`'d and then waits to observe them being used. If, for example, your spec helper requires all your shared examples but you only run a subset of your tests (which don't happen to use all of the aforementioned shared examples), it may appear to `rspectre` like some of those shared examples are unused when they are not. If you do not run your whole test suite, you'll likely have to sift through some false positives.
 
 ### Contributing
 
-Please try out `rspectre` on your codebase--I'd love general feedback and bug reports. If you find something weird or `--auto-correct` eats your dog along with your homework, open an issue!
+Please try out `rspectre` on your codebase--I'd love general feedback and, especially, bug reports. If you find something weird or `--auto-correct` eats your dog along with your homework, open an issue!
 
 Also, if you have an idea for something you think `rspectre` might be able to reasonably detect, feel free to propose it in an issue as well.


### PR DESCRIPTION
- Present a slightly more polished and less experimental view of `rspectre`.
- Remove ruby support notice--this will be determined by the gemspec and, will in turn, generally be the current set of supported ruby versions (though currently `rspectre` supports 2.5 which is EOL).