### PR TITLE
Upgrade development dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,14 @@ AllCops:
   DisplayCopNames: true
 require:
   - rubocop-rspec
-Layout/AlignHash:
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
 Layout/ExtraSpacing:
   AllowForAlignment: true
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
 Layout/FirstArrayElementLineBreak:
   Enabled: true
 Layout/FirstHashElementLineBreak:
@@ -17,10 +20,9 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 Layout/FirstMethodParameterLineBreak:
   Enabled: true
-Layout/IndentArray:
-  EnforcedStyle: consistent
-Layout/IndentHash:
-  EnforcedStyle: consistent
+Layout/HashAlignment:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
 Layout/MultilineArrayBraceLayout:
   Enabled: true
 Layout/MultilineAssignmentLayout:
@@ -34,6 +36,42 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: true
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
 Metrics/AbcSize:
   Enabled: false
 Metrics/MethodLength:
@@ -44,8 +82,10 @@ Metrics/BlockLength:
   Exclude:
     # Ignore RSpec DSL
     - spec/**/*
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
+Naming/RescuedExceptionsVariableName:
+  PreferredName: error
 Style/Next:
   EnforcedStyle: always
 Style/PercentLiteralDelimiters:
@@ -77,25 +117,59 @@ Style/StringMethods:
   Enabled: true
 Style/Alias:
   EnforcedStyle: prefer_alias_method
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
 Style/Documentation:
   Enabled: false
-Style/SignalException:
-  EnforcedStyle: semantic
-Style/SingleLineBlockParams:
-  Enabled: false
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
 Style/GuardClause:
   Enabled: false
 Style/EmptyMethod:
   EnforcedStyle: expanded
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
 Style/LambdaCall:
   Enabled: false
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/SignalException:
+  EnforcedStyle: semantic
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/StringChars: # (new in 1.12)
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
+  Enabled: true
 RSpec/MessageExpectation:
   Enabled: true
 RSpec/ExampleLength:
   Enabled: false
+RSpec/FilePath:
+  Enabled: false
+RSpec/IdenticalEqualityAssertion: # (new in 2.4)
+  Enabled: true
 RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/Rails/AvoidSetupHook: # (new in 2.4)
   Enabled: false
 RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: true
-RSpec/FilePath:
-  Enabled: false

--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -24,7 +24,7 @@ module RSpectre
         if block_given?
           yield node
         else
-          return node
+          node
         end
       end
     end

--- a/lib/rspectre/offense.rb
+++ b/lib/rspectre/offense.rb
@@ -26,16 +26,14 @@ module RSpectre
       puts to_s
     end
 
-    # rubocop:disable Layout/IndentHeredoc
     def to_s
       <<~DOC
 
-          #{source_id}: #{offense_type}: #{description}
-              #{source_line}
-              #{highlight}
+        #{source_id}: #{offense_type}: #{description}
+            #{source_line}
+            #{highlight}
       DOC
     end
-    # rubocop:enable Layout/IndentHeredoc
 
     def description
       DESCRIPTIONS.fetch(type)

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |gem|
   gem.version     = RSpectre::VERSION
   gem.summary     = 'A tool for linting RSpec test suites.'
   gem.authors     = ['Daniel Gollahon']
-  gem.date        = '2017-03-25'
   gem.files       = `git ls-files lib`.split("\n")
   gem.executables = ['rspectre']
   gem.homepage    = 'http://github.com/dgollahon/rspectre'
@@ -20,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('parser',   '>= 2.5')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 
-  gem.add_development_dependency('pry',           '~> 0.10')
-  gem.add_development_dependency('rubocop',       '~> 0.60.0')
-  gem.add_development_dependency('rubocop-rspec', '~> 1.30.1')
+  gem.add_development_dependency('pry',           '~> 0.14')
+  gem.add_development_dependency('rubocop',       '~> 1.17.0')
+  gem.add_development_dependency('rubocop-rspec', '~> 2.4.0')
 end


### PR DESCRIPTION
- Upgrade to the latest `rubocop` and `rubocop-rspec` and enable the latest cops.
- Remove `gem.date` specification from the gemspec, per rubocop, since that should get automatically populated instead when the gem is built.
- Upgrade to the latest `pry`.