### PR TITLE
Add Ruby 3.1 to test matrix ...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,15 @@
-version: 2
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@1.2 # https://github.com/CircleCI-Public/ruby-orb
 
 jobs:
-  build:
+  test:
+    parameters:
+      ruby-version:
+        type: string
     docker:
-      - image: circleci/ruby:2.5.9
+      - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
       CODECLIMATE_REPO_TOKEN: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
     steps:
@@ -12,3 +18,11 @@ jobs:
       - run: bundle exec rubocop
       - run: bundle exec rspec
       - run: bundle exec codeclimate-test-reporter
+
+workflows:
+  build_and_test:
+    jobs:
+      - test:
+          matrix: # https://circleci.com/blog/circleci-matrix-jobs/
+            parameters:
+              ruby-version: ['2.5', '3.1'] # https://github.com/CircleCI-Public/cimg-ruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,23 @@ jobs:
     docker:
       - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
-      CODECLIMATE_REPO_TOKEN: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
+      CC_TEST_REPORTER_ID: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
     steps:
       - checkout
       - run: bundle install
       - run: bundle exec rubocop
+      - run:
+          name: Install Code Climate Test Reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
       - run: bundle exec rspec
-      - run: bundle exec codeclimate-test-reporter
+      - run:
+          name: Upload Code Climate Test Coverage
+          command: |
+            ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.json"
+            ./cc-test-reporter upload-coverage --debug
 
 workflows:
   build_and_test:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ Layout/FirstMethodParameterLineBreak:
 Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
+Layout/LineLength:
+  Max: 100
 Layout/MultilineArrayBraceLayout:
   Enabled: true
 Layout/MultilineAssignmentLayout:
@@ -76,8 +78,6 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
-Metrics/LineLength:
-  Max: 100
 Metrics/BlockLength:
   Exclude:
     # Ignore RSpec DSL

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ source 'https://rubygems.org'
 gemspec
 
 group(:test) do
-  gem 'codeclimate-test-reporter', '~> 1.0.8'
   gem 'simplecov', '~> 0.13.0'
 end

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 
   gem.add_development_dependency('pry',           '~> 0.14')
-  gem.add_development_dependency('rubocop',       '~> 1.17.0')
-  gem.add_development_dependency('rubocop-rspec', '~> 2.4.0')
+  gem.add_development_dependency('rubocop',       '~> 1.24.1')
+  gem.add_development_dependency('rubocop-rspec', '~> 2.7.0')
 end


### PR DESCRIPTION
I've used rspectre on Ruby 3.1 and it works fine.

closes #46

*edit:* this PR also updates rubocop because the old version didn't run on ruby 3 and fixes codeclimate by replacing the no-longer-supported test reporter.

*edit 2:* i'm not familiar with circle ci, but the overall "pending" state [might be expected and might only go away with a change in repo settings]( https://circleci.com/docs/2.0/enable-checks/#troubleshooting-github-checks-waiting-for-status-in-github )