### PR TITLE
Drop support for ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ workflows:
       - build_ruby:
           matrix: # https://circleci.com/blog/circleci-matrix-jobs/
             parameters:
-              ruby-version: ['2.6', '2.7', '3.0', '3.1'] # https://github.com/CircleCI-Public/cimg-ruby
+              ruby-version: ["2.7", "3.0", "3.1"] # https://github.com/CircleCI-Public/cimg-ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
 require:
   - rubocop-rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Master (Unreleased)]
 
+- Dropped support for ruby 2.6 - [#58](https://github.com/dgollahon/rspectre/pull/58) ([@dgollahon])
+
 ## [0.0.4]
 
 - Fixed `parser` version constraint - [#43](https://github.com/dgollahon/rspectre/pull/43) ([@dgollahon]) (+ thanks @chiastolite)

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'http://github.com/dgollahon/rspectre'
   gem.license     = 'MIT'
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency('anima',    '~> 0.3')
   gem.add_runtime_dependency('concord',  '~> 0.1')


### PR DESCRIPTION
- Ruby 2.6 is EOL