### PR TITLE
Use `#bind_call` instead of `#bind` and `#call`

### DIFF
--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -43,7 +43,7 @@ module RSpectre
       scope.__send__(:define_method, method_name) do |*args, &block|
         yield
 
-        original_method.bind(self).(*args, &block)
+        original_method.bind_call(self, *args, &block)
       end
     end
 


### PR DESCRIPTION
- Now that we are on ruby 2.7, we can take advantage of this new method which is slightly more performant. I doubt it's a bottleneck but it should be a slight win.