### PR TITLE
Remove unmaintained gem dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ workflows:
       - build_ruby:
           matrix: # https://circleci.com/blog/circleci-matrix-jobs/
             parameters:
-              ruby-version: ["2.7", "3.0", "3.1"] # https://github.com/CircleCI-Public/cimg-ruby
+              ruby-version: ["2.7", "3.0", "3.1", "3.2"] # https://github.com/CircleCI-Public/cimg-ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  specs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - run: bundle exec rspec
+
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -6,8 +6,6 @@ require 'pathname'
 require 'set'
 require 'stringio'
 
-require 'anima'
-require 'concord'
 require 'parser/current'
 require 'rspec'
 

--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -2,13 +2,13 @@
 
 module RSpectre
   class AutoCorrector < Parser::TreeRewriter
-    include Concord.new(:filename, :nodes, :buffer)
+    attr_reader :filename, :nodes, :buffer
 
     def initialize(filename, nodes)
-      buffer = Parser::Source::Buffer.new("(#{filename})")
+      @filename = filename
+      @nodes = nodes
+      @buffer = Parser::Source::Buffer.new("(#{filename})")
       buffer.source = File.read(filename)
-
-      super(filename, nodes, buffer)
     end
 
     def correct

--- a/lib/rspectre/linter/unused_shared_setup.rb
+++ b/lib/rspectre/linter/unused_shared_setup.rb
@@ -48,10 +48,10 @@ module RSpectre
       # for now.
       def example_group.shared_examples(name, *args, &block)
         if (node = UnusedSharedSetup.register(:shared_examples, caller_locations))
-          super(name, *args) do |*shared_args|
+          super(name, *args) do |*shared_args, **shared_kwargs|
             before { UnusedSharedSetup.record(node) }
 
-            class_exec(*shared_args, &block)
+            class_exec(*shared_args, **shared_kwargs, &block)
           end
         else
           super(name, *args, &block)

--- a/lib/rspectre/node.rb
+++ b/lib/rspectre/node.rb
@@ -26,6 +26,17 @@ module RSpectre
       location.expression.source_line.rstrip
     end
 
+    def eql?(other)
+      instance_of?(other.class) &&
+        file == other.file &&
+        line == other.line &&
+        node == other.node
+    end
+
+    def hash
+      [file, line, node, self.class].hash
+    end
+
     private
 
     def single_line?

--- a/lib/rspectre/node.rb
+++ b/lib/rspectre/node.rb
@@ -2,7 +2,13 @@
 
 module RSpectre
   class Node
-    include Concord::Public.new(:file, :line, :node)
+    attr_reader :file, :line, :node
+
+    def initialize(file, line, node)
+      @file = file
+      @line = line
+      @node = node
+    end
 
     def start_column
       location.column + 1

--- a/lib/rspectre/offense.rb
+++ b/lib/rspectre/offense.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module RSpectre
-  class Offense
-    include Anima.new(:file, :line, :source_line, :start_column, :end_column, :type)
+  Offense = Struct.new(:file, :line, :source_line, :start_column, :end_column, :type, keyword_init: true) do
 
     DESCRIPTIONS = {
       'UnusedLet'         => 'Unused `let` definition.',

--- a/lib/rspectre/runner.rb
+++ b/lib/rspectre/runner.rb
@@ -2,12 +2,13 @@
 
 module RSpectre
   class Runner
-    include Concord.new(:rspec_arguments, :auto_correct)
+    attr_reader :rspec_arguments, :auto_correct
 
     EXIT_SUCCESS = 0
 
-    def initialize(*)
-      super
+    def initialize(rspec_arguments, auto_correct)
+      @rspec_arguments = rspec_arguments
+      @auto_correct = auto_correct
       @rspec_output = StringIO.new
     end
 

--- a/lib/rspectre/source_map.rb
+++ b/lib/rspectre/source_map.rb
@@ -2,10 +2,10 @@
 
 module RSpectre
   class SourceMap
-    include Concord.new(:map)
+    attr_reader :map
 
     def initialize
-      super(Hash.new { [] })
+      @map = Hash.new { [] }
     end
     private_class_method :new
 

--- a/lib/rspectre/source_map/parser.rb
+++ b/lib/rspectre/source_map/parser.rb
@@ -3,7 +3,11 @@
 module RSpectre
   class SourceMap
     class Parser
-      include Concord.new(:file)
+      attr_reader :file
+
+      def initialize(file)
+        @file = file
+      end
 
       def populate(map)
         walk(parsed_source) { |node| map.add(node) }

--- a/lib/rspectre/tracker.rb
+++ b/lib/rspectre/tracker.rb
@@ -2,10 +2,11 @@
 
 module RSpectre
   class Tracker
-    include Concord.new(:registry, :tracker)
+    attr_reader :registry, :tracker
 
     def initialize
-      super(Hash.new { Set.new }, Hash.new { Set.new })
+      @registry = Hash.new { Set.new }
+      @tracker = Hash.new { Set.new }
     end
 
     def register(type, node)

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7'
 
-  gem.add_runtime_dependency('anima',    '~> 0.3')
-  gem.add_runtime_dependency('concord',  '~> 0.1')
   gem.add_runtime_dependency('parser',   '>= 2.6')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe RSpectre::Runner do
              RuntimeError:
                uh oh
              # <file>:2:in `block (2 levels) in <top (required)>'
-             # <file>:56:in `run_specs'
-             # <file>:15:in `lint'
+             # <file>:57:in `run_specs'
+             # <file>:16:in `lint'
 
         Finished in <time> seconds (files took <time> seconds to load)
         1 example, 1 failure

--- a/spec/unused_shared_setup_spec.rb
+++ b/spec/unused_shared_setup_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe RSpectre do
         let(:c) { :value }
       end
 
+      shared_examples 'used with keyword arguments' do |a:|
+        specify { expect(a).to eq(d) }
+      end
+
+      include_examples('used with keyword arguments', a: 50) do
+        let(:d) { 50 }
+      end
+
       shared_examples 'class_exec is needed for proper method inclusion' do
         def zapp_brannigan(*)
           'kif, show them the medal i won'


### PR DESCRIPTION
Many of the gem dependencies seem to no longer be maintained.

This pull request removes the direct dependencies "anima" and "concord", and transitive dependencies "abstract_type", "adamantium", "equalizer", "memoizable", and "thread_safe".