### PR TITLE
Upgrade `parser` to latest version

### DIFF
--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('anima',    '~> 0.3')
   gem.add_runtime_dependency('concord',  '~> 0.1')
-  gem.add_runtime_dependency('parser',   '>= 2.6')
+  gem.add_runtime_dependency('parser',   '>= 3.2.2.1')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 
   gem.add_development_dependency('pry',           '~> 0.14')


### PR DESCRIPTION
- This is just barely ahead of latest `rubocop` so my assumption is that this version constraint shouldn't present a conflict for most adopters. `parser` often has meaningful bugs that do get fixed so I think that unless someone has trouble running things (in which case I am open to relaxing it) it's best to just move to latest and rule out various possible bugs.