### PR TITLE
Remove `anima`, `concord`, and indirect dependencies

### DIFF
--- a/bin/rspectre
+++ b/bin/rspectre
@@ -29,4 +29,4 @@ end.parse(ARGV)
 
 rspec, auto_correct = options.fetch_values(:rspec, :'auto-correct')
 
-RSpectre::Runner.new(rspec, auto_correct).lint
+RSpectre::Runner.new(rspec_arguments: rspec, auto_correct: auto_correct).lint

--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -6,10 +6,10 @@ require 'pathname'
 require 'set'
 require 'stringio'
 
-require 'anima'
-require 'concord'
 require 'parser/current'
 require 'rspec'
+
+require 'rspectre/keyword_struct'
 
 require 'rspectre/auto_corrector'
 require 'rspectre/color'

--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -2,13 +2,13 @@
 
 module RSpectre
   class AutoCorrector < Parser::TreeRewriter
-    include Concord.new(:filename, :nodes, :buffer)
+    include KeywordStruct.new(:filename, :nodes, :buffer)
 
     def initialize(filename, nodes)
       buffer = Parser::Source::Buffer.new("(#{filename})")
       buffer.source = File.read(filename)
 
-      super(filename, nodes, buffer)
+      super(filename: filename, nodes: nodes, buffer: buffer)
     end
 
     def correct

--- a/lib/rspectre/keyword_struct.rb
+++ b/lib/rspectre/keyword_struct.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RSpectre
+  # Heavily influenced by dkubb/equalizer, mbj/concord, and mbj/anima
+  class KeywordStruct < Module
+    def initialize(*names) # rubocop:disable Lint/MissingSuper
+      raise 'Specify at least one keyword name!' if names.empty?
+
+      names.each do |name|
+        next if /\A\w+\z/.match?(name)
+
+        raise "Invalid keyword name #{name.inspect}!"
+      end
+
+      @module =
+        Module.new do
+          attr_reader(*names)
+
+          define_method(:eql?) do |other|
+            other.instance_of?(self.class) && names.all? do |name|
+              __send__(name).eql?(other.__send__(name))
+            end
+          end
+          alias_method :==, :eql?
+
+          define_method(:inspect) do
+            class_name = self.class.name || self.class.inspect
+            attributes = names.map { |name| "#{name}=#{__send__(name).inspect}" }.join(' ')
+            "#<#{class_name} #{attributes}>"
+          end
+        end.tap do |generated_module|
+          generated_module.class_eval(<<~RUBY, __FILE__, __LINE__ + 1) # rubocop:disable Style/DocumentDynamicEvalDefinition
+            def initialize(#{names.map { |name| "#{name}:" }.join(', ')})
+              #{names.map { |name| "@#{name} = #{name}" }.join("\n  ")}
+            end
+          RUBY
+        end
+    end
+
+    def included(descendant)
+      descendant.include(@module)
+    end
+  end
+end

--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -19,7 +19,7 @@ module RSpectre
       raw_node = node_map(file).find_method(selector, line)
 
       if raw_node
-        node = RSpectre::Node.new(file, line, raw_node)
+        node = RSpectre::Node.new(file: file, line: line, node: raw_node)
         TRACKER.register(self::TAG, node)
         if block_given?
           yield node

--- a/lib/rspectre/node.rb
+++ b/lib/rspectre/node.rb
@@ -2,7 +2,7 @@
 
 module RSpectre
   class Node
-    include Concord::Public.new(:file, :line, :node)
+    include KeywordStruct.new(:file, :line, :node)
 
     def start_column
       location.column + 1

--- a/lib/rspectre/offense.rb
+++ b/lib/rspectre/offense.rb
@@ -2,7 +2,7 @@
 
 module RSpectre
   class Offense
-    include Anima.new(:file, :line, :source_line, :start_column, :end_column, :type)
+    include KeywordStruct.new(:file, :line, :source_line, :start_column, :end_column, :type)
 
     DESCRIPTIONS = {
       'UnusedLet'         => 'Unused `let` definition.',

--- a/lib/rspectre/runner.rb
+++ b/lib/rspectre/runner.rb
@@ -2,11 +2,11 @@
 
 module RSpectre
   class Runner
-    include Concord.new(:rspec_arguments, :auto_correct)
+    include KeywordStruct.new(:rspec_arguments, :auto_correct)
 
     EXIT_SUCCESS = 0
 
-    def initialize(*)
+    def initialize(**)
       super
       @rspec_output = StringIO.new
     end

--- a/lib/rspectre/source_map.rb
+++ b/lib/rspectre/source_map.rb
@@ -2,15 +2,15 @@
 
 module RSpectre
   class SourceMap
-    include Concord.new(:map)
+    include KeywordStruct.new(:map)
 
     def initialize
-      super(Hash.new { [] })
+      super(map: Hash.new { [] })
     end
     private_class_method :new
 
     def self.parse(file)
-      self::Parser.new(file).populate(new)
+      self::Parser.new(file: file).populate(new)
     end
 
     def add(node)

--- a/lib/rspectre/source_map/parser.rb
+++ b/lib/rspectre/source_map/parser.rb
@@ -3,7 +3,7 @@
 module RSpectre
   class SourceMap
     class Parser
-      include Concord.new(:file)
+      include KeywordStruct.new(:file)
 
       def populate(map)
         walk(parsed_source) { |node| map.add(node) }

--- a/lib/rspectre/tracker.rb
+++ b/lib/rspectre/tracker.rb
@@ -2,10 +2,10 @@
 
 module RSpectre
   class Tracker
-    include Concord.new(:registry, :tracker)
+    include KeywordStruct.new(:registry, :tracker)
 
     def initialize
-      super(Hash.new { Set.new }, Hash.new { Set.new })
+      super(registry: Hash.new { Set.new }, tracker: Hash.new { Set.new })
     end
 
     def register(type, node)

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7'
 
-  gem.add_runtime_dependency('anima',    '~> 0.3')
-  gem.add_runtime_dependency('concord',  '~> 0.1')
   gem.add_runtime_dependency('parser',   '>= 3.2.2.1')
   gem.add_runtime_dependency('rspec',    '~> 3.0')
 


### PR DESCRIPTION
- Removes `anima` and `concord` and adds a vendored, stripped down version of `anima`. Also removes indirect dependencies on `abstract_type`, `adamantium`, `ice_nine`, `memoizable`, `equalizer`, and `thread_safe` in hopes that this makes the gem more adoptable since it now only depends on `parser` and `rspec`. h/t @bquorning.