### PR TITLE
Test multiple RSpec versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,9 @@
 version: 2.1
 
 jobs:
-  build_ruby:
-    parameters:
-      ruby-version:
-        type: string
+  default_build_with_coverage:
     docker:
-      - image: cimg/ruby:<< parameters.ruby-version >>
+      - image: cimg/ruby:3.2
     environment:
       CC_TEST_REPORTER_ID: c8c9bf91b1e168a3f507a2ef2d2d891eb2e9cf37c06ffd4d0c6ba4b7caf618ab
     steps:
@@ -25,11 +22,32 @@ jobs:
           command: |
             ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.json"
             ./cc-test-reporter upload-coverage --debug
+  build_variants:
+    parameters:
+      ruby-version:
+        type: string
+      rspec-version:
+        type: string
+    docker:
+      - image: cimg/ruby:<< parameters.ruby-version >>
+    steps:
+      - checkout
+      - run:
+          name: Override RSpec version
+          command: sed -i "/'rspec',/s/'~> [0-9]\.[0-9]'/'~> << parameters.rspec-version >>'/" rspectre.gemspec
+      - run:
+          name: Verify RSpec version was overridden
+          command: set +o pipefail && ! git diff --exit-code rspectre.gemspec && set -o pipefail
+      - run: bundle install
+      - run: bundle exec rubocop
+      - run: bundle exec rspec
 
 workflows:
   build:
     jobs:
-      - build_ruby:
+      - default_build_with_coverage
+      - build_variants:
           matrix: # https://circleci.com/blog/circleci-matrix-jobs/
             parameters:
               ruby-version: ["2.7", "3.0", "3.1", "3.2"] # https://github.com/CircleCI-Public/cimg-ruby
+              rspec-version: ["3.9.0", "3.10.0", "3.11.0", "3.12.0"]

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7'
 
-  gem.add_runtime_dependency('parser',   '>= 3.2.2.1')
-  gem.add_runtime_dependency('rspec',    '~> 3.0')
+  gem.add_runtime_dependency('parser', '>= 3.2.2.1')
+  gem.add_runtime_dependency('rspec',  '~> 3.9')
 
   gem.add_development_dependency('pry',           '~> 0.14')
   gem.add_development_dependency('rubocop',       '~> 1.51.0')


### PR DESCRIPTION
- Tests the latest 4 minor versions of RSpec on each version of Ruby
- Extracts the main build for ruby 3.2 into a separate build step and centralizes it as the only step that reports to Code Climate. This should make the other steps very marginally faster and I don't see any reason to have multiple collections of the coverage data.