### PR TITLE
Fix keyword block argument forwarding in Ruby 3.x

### DIFF
--- a/lib/rspectre/linter/unused_shared_setup.rb
+++ b/lib/rspectre/linter/unused_shared_setup.rb
@@ -48,10 +48,10 @@ module RSpectre
       # for now.
       def example_group.shared_examples(name, *args, &block)
         if (node = UnusedSharedSetup.register(:shared_examples, caller_locations))
-          super(name, *args) do |*shared_args|
+          super(name, *args) do |*shared_args, **shared_kwargs|
             before { UnusedSharedSetup.record(node) }
 
-            class_exec(*shared_args, &block)
+            class_exec(*shared_args, **shared_kwargs, &block)
           end
         else
           super(name, *args, &block)

--- a/spec/unused_shared_setup_spec.rb
+++ b/spec/unused_shared_setup_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe RSpectre do
         let(:c) { :value }
       end
 
+      shared_examples 'used with keyword arguments' do |a:|
+        specify { expect(a).to eq(d) }
+      end
+
+      include_examples('used with keyword arguments', a: 50) do
+        let(:d) { 50 }
+      end
+
       shared_examples 'class_exec is needed for proper method inclusion' do
         def zapp_brannigan(*)
           'kif, show them the medal i won'


### PR DESCRIPTION
- When `shared_examples` accepts keyword arguments, we need to forward them properly to the original method in RSpec.
- Author @bquorning originally from #62 
- Note [@dgollahon] this partially breaks ruby 2.7 support in [one specific edge case](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#:~:text=If%20your%20code%20doesn%E2%80%99t%20have%20to%20run%20on%20Ruby%202.6%20or%20older%2C%20you%20may%20try%20the%20new%20style%20in%20Ruby%202.7.%20In%20almost%20all%20cases%2C%20it%20works.%20Note%20that%2C%20however%2C%20there%20are%20unfortunate%20corner%20cases%20as%20follows%3A) so I will follow this up with a more complete fix