### PR TITLE
Generically forward keyword arguments

### DIFF
--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -40,10 +40,10 @@ module RSpectre
     def self.prepend_behavior(scope, method_name)
       original_method = scope.instance_method(method_name)
 
-      scope.__send__(:define_method, method_name) do |*args, &block|
+      scope.__send__(:define_method, method_name) do |*args, **kwargs, &block|
         yield
 
-        original_method.bind_call(self, *args, &block)
+        original_method.bind_call(self, *args, **kwargs, &block)
       end
     end
 


### PR DESCRIPTION
- This should always be safe to do and may be required depending on the method we are hijacking. I did not do this previously due to differences in 2.7 and later versions of ruby but now that [ruby 2.7 is no longer supported](https://github.com/dgollahon/rspectre/pull/72) it makes sense to do this everywhere.
- Related to https://github.com/dgollahon/rspectre/pull/71
- Closes https://github.com/dgollahon/rspectre/issues/46