### PR TITLE
Fix KeywordStruct and add test coverage

### DIFF
--- a/lib/rspectre/keyword_struct.rb
+++ b/lib/rspectre/keyword_struct.rb
@@ -23,6 +23,10 @@ module RSpectre
           end
           alias_method :==, :eql?
 
+          define_method(:hash) do
+            [self.class, *names.map { |name| __send__(name) }].hash
+          end
+
           define_method(:inspect) do
             class_name = self.class.name || self.class.inspect
             attributes = names.map { |name| "#{name}=#{__send__(name).inspect}" }.join(' ')

--- a/spec/keyword_struct_spec.rb
+++ b/spec/keyword_struct_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe RSpectre::KeywordStruct do
+  subject(:struct) { Class.new.include(described_class.new(:foo, :bar)) }
+
+  it 'defines keyword arguments' do
+    expect { struct.new }.to raise_error('missing keywords: :foo, :bar')
+  end
+
+  it 'generates attr_readers' do
+    expect(struct.new(foo: 1, bar: 2)).to have_attributes(
+      foo: 1,
+      bar: 2
+    )
+  end
+
+  describe '#==' do
+    it 'has appropriate equality semantics' do
+      expect(struct.new(foo: 1, bar: 1)).to eq(struct.new(foo: 1, bar: 1)) # rubocop:disable RSpec/IdenticalEqualityAssertion
+      expect(struct.new(foo: 1, bar: 1)).not_to eq(struct.new(foo: 2, bar: 1))
+      expect(struct.new(foo: 1, bar: 1)).not_to eq(struct.new(foo: 1, bar: 2))
+    end
+  end
+
+  describe '#eql?' do
+    it 'has appropriate equality semantics' do
+      expect(struct.new(foo: 1, bar: 1)).to eql(struct.new(foo: 1, bar: 1)) # rubocop:disable RSpec/IdenticalEqualityAssertion
+      expect(struct.new(foo: 1, bar: 1)).not_to eql(struct.new(foo: 2, bar: 1))
+      expect(struct.new(foo: 1, bar: 1)).not_to eql(struct.new(foo: 1, bar: 2))
+    end
+  end
+
+  describe '#hash' do
+    it 'correctly identifies unique elements' do
+      set = [
+        struct.new(foo: 1, bar: 1),
+        struct.new(foo: 1, bar: 1),
+        struct.new(foo: 2, bar: 2)
+      ].to_set
+
+      expect(set.to_a).to eql([struct.new(foo: 1, bar: 1), struct.new(foo: 2, bar: 2)])
+    end
+  end
+
+  describe '#inspect' do
+    it 'produces a legible inspect method' do
+      expect(struct.new(foo: 1, bar: 1).inspect).to match(/<#<Class:0x\h+> foo=1 bar=1>/)
+    end
+  end
+end


### PR DESCRIPTION
- I neglected to implement #hash which breaks `Set` (and `Hash`) based equality operations. This is now fixed.
- Also adds basic test coverage which I should have started with originally.