### PR TITLE
Find block-pass nodes correctly

### DIFF
--- a/lib/rspectre/node.rb
+++ b/lib/rspectre/node.rb
@@ -27,7 +27,11 @@ module RSpectre
     end
 
     def location
-      node.children.first.location
+      if node.type.equal?(:block)
+        node.children.first.location
+      else
+        node.location
+      end
     end
   end
 end

--- a/lib/rspectre/source_map.rb
+++ b/lib/rspectre/source_map.rb
@@ -32,16 +32,33 @@ module RSpectre
     private
 
     def find_methods(target_selector, line)
-      block_nodes(line).select do |node|
-        send, = *node
-        _receiver, selector = *send
+      block_candidates =
+        block_nodes(line).select do |node|
+          send, = *node
+          matching_send?(send, target_selector)
+        end
 
-        selector.equal?(target_selector)
+      if block_candidates.any?
+        block_candidates
+      else
+        send_nodes(line).select do |node|
+          matching_send?(node, target_selector)
+        end
       end
+    end
+
+    def matching_send?(node, method_name)
+      _receiver, selector = *node
+
+      selector.equal?(method_name)
     end
 
     def block_nodes(line)
       map.fetch(line, []).select { |node| node.type.equal?(:block) }
+    end
+
+    def send_nodes(line)
+      map.fetch(line, []).select { |node| node.type.equal?(:send) }
     end
 
     class Null < self

--- a/spec/unused_let_spec.rb
+++ b/spec/unused_let_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe RSpectre do
         let(:used) { 'not actually used' }
         ^^^^^^^^^^ UnusedLet: Unused `let` definition.
       end
+
+      context 'block-pass cases' do
+        def self.block_example(&block)
+          let(:used_block_pass,   &block)
+          let(:unused_block_pass, &block)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UnusedLet: Unused `let` definition.
+        end
+
+        block_example { 'neat!' }
+
+        it 'detects block passes properly' do
+          expect(used_block_pass).to eql('neat!')
+        end
+      end
     end
   RUBY
 end


### PR DESCRIPTION
- We prefer finding `block` nodes because they wrap the `send`. There are cases, however, like with a block pass where we actually do want the `send`. So we can just search for `block` nodes and, if we don't find a match, search for `send` as a fallback.
- Closes #60