### PR TITLE
Improve spec legibility when there are failures

### DIFF
--- a/spec/shared/highlighted_offenses.rb
+++ b/spec/shared/highlighted_offenses.rb
@@ -34,7 +34,12 @@ RSpec.shared_examples 'highlighted offenses' do |source|
 
   it 'highlights the expected offenses' do
     aggregate_failures do
-      run_rspectre(source) do |(stdout, _stderr, status), file|
+      run_rspectre(source) do |(stdout, stderr, status), file|
+        unless stderr.empty?
+          puts 'STDERR:'
+          puts stderr
+        end
+
         offenses = stdout.split("\n").each_slice(4)
         expected_offenses = expected_offenses(source, file)
 


### PR DESCRIPTION
- Previously STDERR was entirely suppressed. This is suboptimal when debugginb because rspectre is being run in another process during these tests and there is no good way to see obvious warnings or failures otherwise.