### PR TITLE
Suppress method redefinition warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Master (Unreleased)]
 
+- Suppress method redefined warnings when `$VERBOSE` is `true` [#80](https://github.com/dgollahon/rspectre/pull/80) ([@dgollahon])
+
 ## [0.1.0]
 
 - Detect `let`s and other constructs using a block-pass like `let(:example, &block)` [#76](https://github.com/dgollahon/rspectre/pull/76) ([@dgollahon])

--- a/lib/rspectre/linter.rb
+++ b/lib/rspectre/linter.rb
@@ -40,6 +40,8 @@ module RSpectre
     def self.prepend_behavior(scope, method_name)
       original_method = scope.instance_method(method_name)
 
+      # Removing the method first prevents method redefined warnings when $VERBOSE is true
+      scope.remove_method(method_name)
       scope.__send__(:define_method, method_name) do |*args, **kwargs, &block|
         yield
 

--- a/spec/shared/highlighted_offenses.rb
+++ b/spec/shared/highlighted_offenses.rb
@@ -64,6 +64,8 @@ RSpec.shared_examples 'highlighted offenses' do |source|
 
           expect(offense.description).to eql(description)
         end
+
+        expect(stderr.empty?).to be(true), 'There was unexpected output to STDERR!'
       end
     end
   end

--- a/spec/shared/rspectre_runner.rb
+++ b/spec/shared/rspectre_runner.rb
@@ -12,7 +12,7 @@ RSpec.shared_context 'rspectre runner' do # rubocop:disable RSpec/ContextWording
 
     output =
       Dir.chdir(File.dirname(spec_file.path)) do
-        Open3.capture3("#{rspectre_path} --rspec #{spec_file.path}")
+        Open3.capture3("RUBYOPT='--verbose' #{rspectre_path} --rspec #{spec_file.path}")
       end
 
     yield([output, spec_file])

--- a/spec/unused_let_spec.rb
+++ b/spec/unused_let_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RSpectre do
       let(:unused_binary) { "\\xff".b }
       ^^^^^^^^^^^^^^^^^^^ UnusedLet: Unused `let` definition.
 
-      let(:unused_compound) { 1 + 1; 'noop' }
+      let(:unused_compound) { foo; 'noop' }
       ^^^^^^^^^^^^^^^^^^^^^ UnusedLet: Unused `let` definition.
 
       let(
@@ -26,7 +26,7 @@ RSpec.describe RSpectre do
 
       let(:unused_multiline_compound) do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UnusedLet: Unused `let` definition.
-        'doop'
+        foo
         'noop'
       end
 


### PR DESCRIPTION
- When running with `$VERBOSE` set to `true`, rspectre generates a very large # of method redefinition warnings. We can suppress those by removing the method before redefining it. This is very slightly less performant but I think it's worth it.
- Also enforces that we have no STDERR output in CI. Required slightly modifying a couple of spec examples that triggered warnings.