### PR TITLE
Rotate `ruby` and `rspec` versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - run:
           name: Override RSpec version
-          command: sed -i "/'rspec',/s/'~> [0-9]\.[0-9]'/'~> << parameters.rspec-version >>'/" rspectre.gemspec
+          command: sed -i "/'rspec',/s/'~> [0-9]\.[0-9]\+'/'~> << parameters.rspec-version >>'/" rspectre.gemspec
       - run:
           name: Verify RSpec version was overridden
           command: set +o pipefail && ! git diff --exit-code rspectre.gemspec && set -o pipefail
@@ -56,5 +56,5 @@ workflows:
       - build_variants:
           matrix: # https://circleci.com/blog/circleci-matrix-jobs/
             parameters:
-              ruby-version: ["3.0", "3.1", "3.2"] # https://github.com/CircleCI-Public/cimg-ruby
-              rspec-version: ["3.9.0", "3.10.0", "3.11.0", "3.12.0"]
+              ruby-version: ["3.0", "3.1", "3.2", "3.3"] # https://github.com/CircleCI-Public/cimg-ruby
+              rspec-version: ["3.10.0", "3.11.0", "3.12.0", "3.13.0"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You should generally run your _entire_ test suite with `rspectre`. `rspectre` in
 
 ### Supported Tool Versions
 
-My intent is to support all non-EOL ruby versions and the last 4 minor versions of `rspec`. At the time of writing (2023-05-13), those are (`3.0`, `3.1`, `3.2`) and (`3.9`, `3.10`, `3.11`, and `3.12`, respectively). If you encounter an issue on a different version of `rspec`, please try upgrading first. If you still have a problem, please file an issue.
+My intent is to support all non-EOL ruby versions and the last 4 minor versions of `rspec`. At the time of writing (2024-11-28), those are (`3.0`, `3.1`, `3.2`) and (`3.10`, `3.11`, `3.12`, and `3.13`, respectively). If you encounter an issue on a different version of `rspec`, please try upgrading first. If you still have a problem, please file an issue.
 
 ### Contributing
 

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -15,10 +15,11 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.0'
 
   gem.add_runtime_dependency('parser', '>= 3.2.2.1')
-  gem.add_runtime_dependency('rspec',  '~> 3.9')
+  gem.add_runtime_dependency('rspec',  '~> 3.10')
 
   gem.add_development_dependency('pry',           '~> 0.14')
   gem.add_development_dependency('rubocop',       '~> 1.51.0')
+  gem.add_development_dependency('rubocop-factory_bot', '!= 2.26.0')
   gem.add_development_dependency('rubocop-rspec', '~> 2.22.0')
 
   gem.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
See https://endoflife.date/ruby and https://rubygems.org/gems/rspec/versions

For `gem.add_development_dependency('rubocop-factory_bot', '!= 2.26.0')` change take a look at https://github.com/rubocop/rubocop-rspec/issues/1916