### PR TITLE
Remove `pry` as a development dependency

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,6 +7,6 @@ require 'bundler/setup'
 
 require 'rspectre'
 
-require 'pry'
+require 'irb'
 
-Pry.start
+IRB.start

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('parser', '>= 3.2.2.1')
   gem.add_runtime_dependency('rspec',  '~> 3.10')
 
-  gem.add_development_dependency('pry',           '~> 0.14')
-  gem.add_development_dependency('rubocop',       '~> 1.51.0')
+  gem.add_development_dependency('rubocop', '~> 1.51.0')
   gem.add_development_dependency('rubocop-factory_bot', '!= 2.26.0')
   gem.add_development_dependency('rubocop-rspec', '~> 2.22.0')
 


### PR DESCRIPTION
- `irb` has caught up with pry in all the features I care about, remove `pry` as a dependency.