### PR TITLE
Upgrade `rubocop` and `rubocop-rspec` to latest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,11 @@
 ---
 AllCops:
-  TargetRubyVersion: 3.0
   DisplayCopNames: true
+  TargetRubyVersion: 3.0
 require:
   - rubocop-rspec
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
 Gemspec/DeprecatedAttributeAssignment: # (new in 1.10)
   Enabled: true
 Gemspec/DevelopmentDependencies:
@@ -12,10 +14,10 @@ Gemspec/RequireMFA: # new in 1.23
   Enabled: true
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
 Layout/FirstArrayElementLineBreak:
   Enabled: true
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
 Layout/FirstHashElementLineBreak:
   Enabled: true
 Layout/FirstMethodArgumentLineBreak:
@@ -34,8 +36,8 @@ Layout/LineEndStringConcatenationIndentation: # new in 1.18
 Layout/LineLength:
   Max: 100
 Layout/MultilineAssignmentLayout:
-  EnforcedStyle: new_line
   Enabled: true
+  EnforcedStyle: new_line
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/SpaceBeforeBrackets: # (new in 1.7)
@@ -46,31 +48,23 @@ Lint/AmbiguousOperatorPrecedence: # new in 1.21
   Enabled: false
 Lint/AmbiguousRange: # new in 1.19
   Enabled: true
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
 Lint/ConstantOverwrittenInRescue: # new in 1.31
   Enabled: true
-Lint/DuplicateMagicComment: # new in 1.37
-  Enabled: true
-Lint/DuplicateMatchPattern: # new in 1.50
-  Enabled: true
-Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
-  Enabled: true
-Lint/NonAtomicFileOperation: # new in 1.31
-  Enabled: true
-Lint/RefinementImportMethods: # new in 1.27
-  Enabled: true
-Lint/RequireRangeParentheses: # new in 1.32
-  Enabled: true
-Lint/RequireRelativeSelfPath: # new in 1.22
-  Enabled: true
-Lint/UselessRescue: # new in 1.43
-  Enabled: true
-Lint/UselessRuby2Keywords: # new in 1.23
+Lint/ConstantReassignment: # new in 1.70
   Enabled: true
 Lint/DeprecatedConstants: # (new in 1.8)
   Enabled: true
 Lint/DuplicateBranch: # (new in 1.3)
   Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
 Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
   Enabled: true
 Lint/EmptyBlock: # (new in 1.1)
   Enabled: true
@@ -78,15 +72,39 @@ Lint/EmptyClass: # (new in 1.3)
   Enabled: true
 Lint/EmptyInPattern: # (new in 1.16)
   Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
 Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/MixedCaseRange: # new in 1.53
   Enabled: true
 Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
   Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
 Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
   Enabled: true
 Lint/OrAssignmentToConstant: # (new in 1.9)
   Enabled: true
 Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
   Enabled: true
 Lint/SymbolConversion: # (new in 1.9)
   Enabled: true
@@ -94,9 +112,19 @@ Lint/ToEnumArguments: # (new in 1.1)
   Enabled: true
 Lint/TripleQuotes: # (new in 1.9)
   Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
 Lint/UnexpectedBlockArity: # (new in 1.5)
   Enabled: true
 Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Lint/UselessRescue: # new in 1.43
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
   Enabled: true
 Metrics/AbcSize:
   Enabled: false
@@ -118,144 +146,6 @@ Naming/MethodParameterName:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   PreferredName: error
-Security/CompoundHash: # new in 1.28
-  Enabled: false
-Style/ComparableClamp: # new in 1.44
-  Enabled: true
-
-Security/IoMethods: # new in 1.22
-  Enabled: true
-Style/ArrayIntersect: # new in 1.40
-  Enabled: true
-Style/FileRead: # new in 1.24
-  Enabled: true
-Style/FileWrite: # new in 1.24
-  Enabled: true
-Style/MapToHash: # new in 1.24
-  Enabled: true
-Style/MultilineBlockChain:
-  Enabled: false
-Style/NumberedParameters: # new in 1.22
-  Enabled: true
-Style/NumberedParametersLimit: # new in 1.22
-  Enabled: false
-Style/OpenStructUse: # new in 1.23
-  Enabled: true
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    "%i": "[]"
-    "%I": "[]"
-    "%q": "{}"
-    "%Q": "{}"
-    "%r": "{}"
-    "%s": ()
-    "%w": "[]"
-    "%W": "[]"
-    "%x": ()
-Style/RedundantSelfAssignmentBranch: # new in 1.19
-  Enabled: true
-Style/SelectByRegexp: # new in 1.22
-  Enabled: true
-Style/TrivialAccessors:
-  ExactNameMatch: false
-Style/BarePercentLiterals:
-  EnforcedStyle: percent_q
-Style/CollectionMethods:
-  Enabled: true
-Style/ConcatArrayLiterals: # new in 1.41
-  Enabled: true
-Style/Send:
-  Enabled: true
-Style/AutoResourceCleanup:
-  Enabled: true
-Style/OptionHash:
-  Enabled: true
-Style/StringMethods:
-  Enabled: true
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-Style/ArgumentsForwarding: # (new in 1.1)
-  Enabled: true
-Style/CollectionCompact: # (new in 1.2)
-  Enabled: true
-Style/DataInheritance: # new in 1.49
-  Enabled: true
-Style/Documentation:
-  Enabled: false
-Style/DocumentDynamicEvalDefinition: # (new in 1.1)
-  Enabled: true
-Style/DirEmpty: # new in 1.48
-  Enabled: true
-Style/EmptyHeredoc: # new in 1.32
-  Enabled: true
-Style/EnvHome: # new in 1.29
-  Enabled: true
-Style/ExactRegexpMatch: # new in 1.51
-  Enabled: true
-Style/FetchEnvVar:
-  Enabled: false # Generally covered by mutant, may be noisy if intended
-Style/GuardClause:
-  Enabled: false
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-Style/EndlessMethod: # (new in 1.8)
-  Enabled: true
-Style/FileEmpty: # new in 1.48
-  Enabled: true
-Style/HashConversion: # (new in 1.10)
-  Enabled: true
-Style/HashExcept: # (new in 1.7)
-  Enabled: true
-Style/IfWithBooleanLiteralBranches: # (new in 1.9)
-  Enabled: true
-Style/InPatternThen: # (new in 1.16)
-  Enabled: true
-Style/LambdaCall:
-  Enabled: false
-Style/MagicCommentFormat: # new in 1.35
-  Enabled: true
-Style/MapCompactWithConditionalBlock: # new in 1.30
-  Enabled: true
-Style/MapToSet: # new in 1.42
-  Enabled: true
-Style/MinMaxComparison: # new in 1.42
-  Enabled: true
-Style/MultilineInPatternThen: # (new in 1.16)
-  Enabled: true
-Style/NegatedIfElseCondition: # (new in 1.2)
-  Enabled: true
-Style/NestedFileDirname: # new in 1.26
-  Enabled: true
-Style/NilLambda: # (new in 1.3)
-  Enabled: true
-Style/ObjectThen: # new in 1.28
-  Enabled: true
-Style/OperatorMethodCall: # new in 1.37
-  Enabled: true
-Style/QuotedSymbols: # (new in 1.16)
-  Enabled: true
-Style/RedundantArgument: # (new in 1.4)
-  Enabled: true
-Style/RedundantConstantBase:
-  Enabled: false # I don't trust this one to be correct and Mutant can solve for it most of the time as well.
-Style/RedundantDoubleSplatHashBraces: # new in 1.41
-  Enabled: true
-Style/RedundantEach: # new in 1.38
-  Enabled: true
-Style/RedundantHeredocDelimiterQuotes:
-  Enabled: false # I deliberately use both styles
-Style/RedundantInitialize: # new in 1.27
-  Enabled: true
-Style/RedundantLineContinuation: # new in 1.49
-  Enabled: true
-Style/RedundantStringEscape: # new in 1.37
-  Enabled: true
-Style/SingleLineBlockParams:
-  Enabled: false
-Style/StringChars: # (new in 1.12)
-  Enabled: true
-Style/SwapValues: # (new in 1.1)
-  Enabled: true
 RSpec/BeEmpty:
   Enabled: false # I like to be explicit with eql([])
 RSpec/BeEq: # new in 2.9.0
@@ -268,16 +158,14 @@ RSpec/ContainExactly: # new in 2.19
   Enabled: true
 RSpec/DuplicatedMetadata: # new in 2.16
   Enabled: true
-RSpec/ExcessiveDocstringSpacing: # new in 2.5
-  Enabled: true
 RSpec/ExampleLength:
   Enabled: false
-RSpec/FilePath:
-  Enabled: false
-RSpec/IndexedLet:
-  Enabled: false # Too pedantic, numbering is sometimes OK
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
 RSpec/IdenticalEqualityAssertion: # (new in 2.4)
   Enabled: true
+RSpec/IndexedLet:
+  Enabled: false # Too pedantic, numbering is sometimes OK
 RSpec/MatchArray: # new in 2.19
   Enabled: true
 RSpec/MessageExpectation:
@@ -294,15 +182,194 @@ RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
+RSpec/SpecFilePathFormat:
+  Enabled: false
 RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
 RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: true
-RSpec/VerifiedDoubleReference: # new in 2.10.0
+Security/CompoundHash: # new in 1.28
+  Enabled: false
+Security/IoMethods: # new in 1.22
   Enabled: true
-Capybara:
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/AutoResourceCleanup:
+  Enabled: true
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/ComparableClamp: # new in 1.44
+  Enabled: true
+Style/ConcatArrayLiterals: # new in 1.41
+  Enabled: true
+Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/DirEmpty: # new in 1.48
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/Documentation:
   Enabled: false
-FactoryBot:
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/ExactRegexpMatch: # new in 1.51
+  Enabled: true
+Style/FetchEnvVar:
+  Enabled: false # Generally covered by mutant, may be noisy if intended
+Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/GuardClause:
   Enabled: false
-RSpec/Rails:
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/HashSlice: # new in 1.71
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/LambdaCall:
   Enabled: false
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/MapToSet: # new in 1.42
+  Enabled: true
+Style/MinMaxComparison: # new in 1.42
+  Enabled: true
+Style/MultilineBlockChain:
+  Enabled: false
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: false
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/OptionHash:
+  Enabled: true
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%I": "[]"
+    "%Q": "{}"
+    "%W": "[]"
+    "%i": "[]"
+    "%q": "{}"
+    "%r": "{}"
+    "%s": ()
+    "%w": "[]"
+    "%x": ()
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/RedundantArrayConstructor: # new in 1.52
+  Enabled: true
+Style/RedundantConstantBase:
+  Enabled: false # I don't trust this one to be correct and Mutant can solve for it most of the time as well.
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantDoubleSplatHashBraces: # new in 1.41
+  Enabled: true
+Style/RedundantEach: # new in 1.38
+  Enabled: true
+Style/RedundantFilterChain: # new in 1.52
+  Enabled: true
+Style/RedundantHeredocDelimiterQuotes:
+  Enabled: false # I deliberately use both styles
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpConstructor: # new in 1.52
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/Send:
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/SingleLineDoEndBlock: # new in 1.57
+  Enabled: true
+Style/StringChars: # (new in 1.12)
+  Enabled: true
+Style/StringMethods:
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
+  Enabled: true
+Style/TrivialAccessors:
+  ExactNameMatch: false
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true

--- a/lib/rspectre/linter/unused_let.rb
+++ b/lib/rspectre/linter/unused_let.rb
@@ -6,7 +6,7 @@ module RSpectre
       TAG = 'UnusedLet'
 
       def example_group.let(name, &block)
-        super(name, &block)
+        super
 
         UnusedLet.register(:let, caller_locations) do |node|
           UnusedLet.prepend_behavior(self, name) { UnusedLet.record(node) }

--- a/lib/rspectre/linter/unused_shared_setup.rb
+++ b/lib/rspectre/linter/unused_shared_setup.rb
@@ -48,37 +48,37 @@ module RSpectre
       # for now.
       def example_group.shared_examples(name, *args, **kwargs, &block)
         if (node = UnusedSharedSetup.register(:shared_examples, caller_locations))
-          super(name, *args, **kwargs) do |*shared_args, **shared_kwargs|
+          super do |*shared_args, **shared_kwargs|
             before { UnusedSharedSetup.record(node) }
 
             class_exec(*shared_args, **shared_kwargs, &block)
           end
         else
-          super(name, *args, **kwargs, &block)
+          super
         end
       end
 
       def example_group.shared_examples_for(name, *args, **kwargs, &block)
         if (node = UnusedSharedSetup.register(:shared_examples_for, caller_locations))
-          super(name, *args, **kwargs) do |*shared_args, **shared_kwargs|
+          super do |*shared_args, **shared_kwargs|
             before { UnusedSharedSetup.record(node) }
 
             class_exec(*shared_args, **shared_kwargs, &block)
           end
         else
-          super(name, *args, **kwargs, &block)
+          super
         end
       end
 
       def example_group.shared_context(name, *args, **kwargs, &block)
         if (node = UnusedSharedSetup.register(:shared_context, caller_locations))
-          super(name, *args, **kwargs) do |*shared_args, **shared_kwargs|
+          super do |*shared_args, **shared_kwargs|
             before { UnusedSharedSetup.record(node) }
 
             class_exec(*shared_args, **shared_kwargs, &block)
           end
         else
-          super(name, *args, **kwargs, &block)
+          super
         end
       end
     end

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -14,12 +14,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.0'
 
-  gem.add_runtime_dependency('parser', '>= 3.2.2.1')
-  gem.add_runtime_dependency('rspec',  '~> 3.10')
+  gem.add_dependency('parser', '>= 3.2.2.1')
+  gem.add_dependency('rspec',  '~> 3.10')
 
-  gem.add_development_dependency('rubocop', '~> 1.51.0')
-  gem.add_development_dependency('rubocop-factory_bot', '!= 2.26.0')
-  gem.add_development_dependency('rubocop-rspec', '~> 2.22.0')
+  gem.add_development_dependency('rubocop', '~> 1.71.2')
+  gem.add_development_dependency('rubocop-rspec', '~> 3.4.0')
 
   gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
- Also sorts the .rubocop.yml entries and enables new cops