### PR TITLE
Add support for ruby 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,5 +56,5 @@ workflows:
       - build_variants:
           matrix: # https://circleci.com/blog/circleci-matrix-jobs/
             parameters:
-              ruby-version: ["3.1", "3.2", "3.3"] # https://github.com/CircleCI-Public/cimg-ruby
+              ruby-version: ["3.1", "3.2", "3.3", "3.4"] # https://github.com/CircleCI-Public/cimg-ruby
               rspec-version: ["3.10.0", "3.11.0", "3.12.0", "3.13.0"]

--- a/lib/rspectre.rb
+++ b/lib/rspectre.rb
@@ -6,8 +6,24 @@ require 'pathname'
 require 'set'
 require 'stringio'
 
-require 'parser/current'
 require 'rspec'
+module RSpectre
+  LIB_PATH = Pathname.new(File.expand_path('../lib', __dir__))
+
+  MINIMUM_RUBY_FOR_PRISM = Gem::Version.new('3.3')
+  private_constant(:MINIMUM_RUBY_FOR_PRISM)
+
+  def self.ruby_version_supports_prism?
+    Gem::Version.new(RUBY_VERSION) >= MINIMUM_RUBY_FOR_PRISM
+  end
+end
+
+if RSpectre.ruby_version_supports_prism?
+  require 'parser'
+  require 'prism'
+else
+  require 'parser/current'
+end
 
 require 'rspectre/keyword_struct'
 
@@ -28,5 +44,4 @@ require 'rspectre/linter/unused_shared_setup'
 
 module RSpectre
   TRACKER = Tracker.new
-  LIB_PATH = Pathname.new(File.expand_path('../lib', __dir__))
 end

--- a/lib/rspectre/auto_corrector.rb
+++ b/lib/rspectre/auto_corrector.rb
@@ -14,7 +14,7 @@ module RSpectre
     def correct
       File.write(
         filename,
-        rewrite(buffer, Parser::CurrentRuby.new.parse(buffer))
+        rewrite(buffer, SourceMap::Parser.parser_class.new.parse(buffer))
       )
     end
 

--- a/lib/rspectre/source_map/parser.rb
+++ b/lib/rspectre/source_map/parser.rb
@@ -15,6 +15,14 @@ module RSpectre
         Null.new
       end
 
+      def self.parser_class
+        if RSpectre.ruby_version_supports_prism?
+          Prism::Translation::Parser
+        else
+          ::Parser::CurrentRuby
+        end
+      end
+
       private
 
       def walk(node, &block)
@@ -28,9 +36,8 @@ module RSpectre
       end
 
       def parsed_source
-        parser = ::Parser::CurrentRuby.new(PermissiveASTBuilder.new)
+        parser = self.class.parser_class.new(PermissiveASTBuilder.new)
         buffer = ::Parser::Source::Buffer.new(file, source: raw_source)
-
         parser.parse(buffer)
       end
 

--- a/rspectre.gemspec
+++ b/rspectre.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.1'
 
-  gem.add_dependency('parser', '>= 3.2.2.1')
+  gem.add_dependency('parser', '>= 3.3.7.1')
+  gem.add_dependency('prism',  '~> 1.3')
   gem.add_dependency('rspec',  '~> 3.10')
 
   gem.add_development_dependency('rubocop', '~> 1.71.2')

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -31,7 +31,10 @@ RSpec.describe RSpectre::Runner do
       expect(status.to_i).to be > 0
       expect(stdout).to eql('')
       expect(
+        # The Runner# and ` `gsub`s handles the differences in stack traces between Ruby versions.
         stderr.gsub(/\d\.\d+/, '<time>').gsub(/\S+\.rb/, '<file>').strip
+          .gsub('RSpectre::Runner#', '')
+          .gsub('`', "'")
       ).to eql(<<~ERROR.strip)
         \e[31mRunning the specs failed. Either your tests do not pass normally or this is a bug in RSpectre.\e[0m
 
@@ -46,9 +49,9 @@ RSpec.describe RSpectre::Runner do
 
              RuntimeError:
                uh oh
-             # <file>:2:in `block (2 levels) in <top (required)>'
-             # <file>:56:in `run_specs'
-             # <file>:15:in `lint'
+             # <file>:2:in 'block (2 levels) in <top (required)>'
+             # <file>:56:in 'run_specs'
+             # <file>:15:in 'lint'
 
         Finished in <time> seconds (files took <time> seconds to load)
         1 example, 1 failure

--- a/spec/unused_let_spec.rb
+++ b/spec/unused_let_spec.rb
@@ -68,4 +68,13 @@ RSpec.describe RSpectre do
       end
     end
   RUBY
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4')
+    include_examples 'highlighted offenses', <<~RUBY
+      RSpec.describe 'unused lets' do
+        let(:unused) { it }
+        ^^^^^^^^^^^^ UnusedLet: Unused `let` definition.
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- Adds `prism` as a dependency to be used on ruby 3.3+. The `parser` is kept to support ruby 3.1 and 3.2 for now.