### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Master (Unreleased)]
 
+## [0.2.0]
+
 - Fix argument forwarding in shared examples and contexts [#91](https://github.com/dgollahon/rspectre/pull/91) ([@dgollahon])
 - Add support for ruby 3.4 [#89](https://github.com/dgollahon/rspectre/pull/89) ([@dgollahon])
 - Remove support for ruby 3.0 [#88](https://github.com/dgollahon/rspectre/pull/88) ([@dgollahon])
@@ -42,7 +44,8 @@
 
 <!-- Version diffs -->
 
-[master (unreleased)]: https://github.com/dgollahon/rspectre/compare/v0.1.0...HEAD
+[master (unreleased)]: https://github.com/dgollahon/rspectre/compare/v0.2.0...HEAD
+[0.1.0]: https://github.com/dgollahon/rspectre/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dgollahon/rspectre/compare/v0.0.4...v0.1.0
 [0.0.4]: https://github.com/dgollahon/rspectre/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/dgollahon/rspectre/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You should generally run your _entire_ test suite with `rspectre`. `rspectre` in
 
 ### Supported Tool Versions
 
-My intent is to support all non-EOL ruby versions and the last 4 minor versions of `rspec`. At the time of writing (2024-11-28), those are (`3.0`, `3.1`, `3.2`) and (`3.10`, `3.11`, `3.12`, and `3.13`, respectively). If you encounter an issue on a different version of `rspec`, please try upgrading first. If you still have a problem, please file an issue.
+My intent is to support all non-EOL ruby versions and the last 4 minor versions of `rspec`. At the time of writing (2024-11-28), those are (`3.1`, `3.2`, `3.3`, `3.4`) and (`3.10`, `3.11`, `3.12`, and `3.13`, respectively). If you encounter an issue on a different version of `rspec`, please try upgrading first. If you still have a problem, please file an issue.
 
 ### Contributing
 

--- a/lib/rspectre/version.rb
+++ b/lib/rspectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RSpectre
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
Includes one bugfix and the following features in addition to some minor internal adjustments:
- Fix argument forwarding in shared examples and contexts [#91](https://github.com/dgollahon/rspectre/pull/91)
- Add support for ruby 3.4 [#89](https://github.com/dgollahon/rspectre/pull/89)
- Remove support for ruby 3.0 [#88](https://github.com/dgollahon/rspectre/pull/88)
- Suppress method redefined warnings when `$VERBOSE` is `true` [#80](https://github.com/dgollahon/rspectre/pull/80)