### PR TITLE
Fix shared example argument forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Master (Unreleased)]
 
+- Fix argument forwarding in shared examples and contexts [#91](https://github.com/dgollahon/rspectre/pull/91) ([@dgollahon])
 - Add support for ruby 3.4 [#89](https://github.com/dgollahon/rspectre/pull/89) ([@dgollahon])
 - Remove support for ruby 3.0 [#88](https://github.com/dgollahon/rspectre/pull/88) ([@dgollahon])
 - Suppress method redefined warnings when `$VERBOSE` is `true` [#80](https://github.com/dgollahon/rspectre/pull/80) ([@dgollahon])

--- a/lib/rspectre/linter/unused_shared_setup.rb
+++ b/lib/rspectre/linter/unused_shared_setup.rb
@@ -10,21 +10,21 @@ module RSpectre
         original_method = receiver.method(method)
 
         # Overwrite the class method using define_singleton_method
-        receiver.__send__(:define_singleton_method, method) do |name, *args, **kwargs, &block|
+        receiver.__send__(:define_singleton_method, method) do |name, *args, &block|
           # When we can locate the source of the node, tag it
           if (node = UnusedSharedSetup.register(method, caller_locations))
             # And call the original
-            original_method.(name, *args, **kwargs) do |*shared_args, **shared_kwargs|
+            original_method.(name, *args) do |*shared_args|
               # But record that it was used in a `before`
               before { UnusedSharedSetup.record(node) }
 
               # And then perform the original block in a `class_exec` like the original block was
               # supposed to be
-              class_exec(*shared_args, **shared_kwargs, &block)
+              RSpec::Support::WithKeywordsWhenNeeded.class_exec(self, *shared_args, &block)
             end
           else
             # If we couldn't locate the source, just delegate to the original method.
-            original_method.(name, *args, **kwargs, &block)
+            original_method.(name, *args, &block)
           end
         end
       end
@@ -46,36 +46,36 @@ module RSpectre
       # terms of the old method. I think we can probably do some kind of module inclusion to reduce
       # this duplication (which is effectively what happens here anyway, i think), but this works
       # for now.
-      def example_group.shared_examples(name, *args, **kwargs, &block)
+      def example_group.shared_examples(name, *args, &block)
         if (node = UnusedSharedSetup.register(:shared_examples, caller_locations))
-          super do |*shared_args, **shared_kwargs|
+          super do |*shared_args|
             before { UnusedSharedSetup.record(node) }
 
-            class_exec(*shared_args, **shared_kwargs, &block)
+            RSpec::Support::WithKeywordsWhenNeeded.class_exec(self, *shared_args, &block)
           end
         else
           super
         end
       end
 
-      def example_group.shared_examples_for(name, *args, **kwargs, &block)
+      def example_group.shared_examples_for(name, *args, &block)
         if (node = UnusedSharedSetup.register(:shared_examples_for, caller_locations))
-          super do |*shared_args, **shared_kwargs|
+          super do |*shared_args|
             before { UnusedSharedSetup.record(node) }
 
-            class_exec(*shared_args, **shared_kwargs, &block)
+            RSpec::Support::WithKeywordsWhenNeeded.class_exec(self, *shared_args, &block)
           end
         else
           super
         end
       end
 
-      def example_group.shared_context(name, *args, **kwargs, &block)
+      def example_group.shared_context(name, *args, &block)
         if (node = UnusedSharedSetup.register(:shared_context, caller_locations))
-          super do |*shared_args, **shared_kwargs|
+          super do |*shared_args|
             before { UnusedSharedSetup.record(node) }
 
-            class_exec(*shared_args, **shared_kwargs, &block)
+            RSpec::Support::WithKeywordsWhenNeeded.class_exec(self, *shared_args, &block)
           end
         else
           super

--- a/spec/unused_shared_setup_spec.rb
+++ b/spec/unused_shared_setup_spec.rb
@@ -69,7 +69,15 @@ RSpec.describe RSpectre do
       end
 
       shared_examples 'used with keyword arguments' do |a:|
+        include_context 'context with keyword arguments', a: a
+
         specify { expect(a).to eq(d) }
+      end
+
+      shared_context 'context with keyword arguments' do |a:|
+        it 'is ok to include' do
+          expect(a).to eq(d)
+        end
       end
 
       include_examples('used with keyword arguments', a: 50) do
@@ -84,6 +92,27 @@ RSpec.describe RSpectre do
         before { zapp_brannigan }
       end
 
+      let(:some_object_hash) { { a: 1 } }
+
+      shared_context 'varying keyword and positional hash arguments' do |attrs|
+        let(:some_object_hash) { super().merge(attrs)}
+
+        it 'is a hash' do
+          expect(some_object_hash).to eql(a: 1)
+        end
+      end
+
+      shared_examples 'keyword argument attributes' do |**attrs|
+        include_examples 'varying keyword and positional hash arguments', attrs
+
+        let(:foo) { attrs }
+
+        it 'is a hash' do
+          expect(foo).to eql({})
+        end
+      end
+
+      it_behaves_like 'keyword argument attributes'
       include_examples 'used example'
       include_examples 'used global constant form'
       include_examples 'used global'


### PR DESCRIPTION
- RSpec forwards a set of positional arguments and converts them to/from keyword as necessary. They have a helper to do this. The way I was forwarding the arguments was incompatible with this in a few niche cases where examples included each other and one was using keyword arguments and the otherw as not.